### PR TITLE
Pushing platform specific build can now be disabled

### DIFF
--- a/src/main/groovy/org/mini2Dx/butler/task/PushTask.groovy
+++ b/src/main/groovy/org/mini2Dx/butler/task/PushTask.groovy
@@ -49,7 +49,7 @@ class PushTask extends DefaultTask  {
 	}
 	
 	def pushAnyOsBuild() {
-		if(project.getExtensions().findByName('butler').anyOs.binDirectory == null) {
+		if(project.getExtensions().findByName('butler').anyOs?.binDirectory == null) {
 			return false;
 		}
 		def osBinDir = project.getExtensions().findByName('butler').anyOs.binDirectory
@@ -63,19 +63,19 @@ class PushTask extends DefaultTask  {
 		String channel;
 
 		if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-			if(project.getExtensions().findByName('butler').windows == null) {
+			if(project.getExtensions().findByName('butler').windows?.binDirectory == null) {
 				return false;
 			}
 			osBinDir = project.getExtensions().findByName('butler').windows.binDirectory
 			channel = project.getExtensions().findByName('butler').windows.channel
 		} else if (Os.isFamily(Os.FAMILY_MAC)) {
-			if(project.getExtensions().findByName('butler').osx == null) {
+			if(project.getExtensions().findByName('butler').osx?.binDirectory == null) {
 				return false;
 			}
 			osBinDir = project.getExtensions().findByName('butler').osx.binDirectory
 			channel = project.getExtensions().findByName('butler').osx.channel
 		} else {
-			if(project.getExtensions().findByName('butler').linux == null) {
+			if(project.getExtensions().findByName('butler').linux?.binDirectory == null) {
 				return false;
 			}
 			osBinDir = project.getExtensions().findByName('butler').linux.binDirectory


### PR DESCRIPTION
Currently for anybody just using the anyOs block, the plugin will try to upload the platform specific build no matter what. This pull request provides a way to disable pushing the platform specific build by setting the binDirectory to null for that specific platform block. 

This will also provide a fix for issue #5 by being able to disable the pushing of the windows build.

PS: I don't see any reason for having the pushed binaries to depend on the OS I'm currently working on. I am perfectly capable of creating builds for multiple systems on my computer. Being able to just configure multiple tasks/channels seems to be the easier solution. This change at least provides a work around. I saw the fork of user @DenialAdams going into the right direction, but he seems to have abandoned his fork... https://github.com/DenialAdams/gradle-butler-plugin/commit/f4e5ec7e8f7113196ae8f07244d7d4bb66ae8f57